### PR TITLE
Add support for returning mulitiple arguments via the callback in the 'pb.make' case.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 /test
 /coverage
-.travis.yml
-.eslintrc
+/.travis.yml
+/.eslintrc
+/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+v3.0.0
+------
+
+* Breaking Change - When using `pb.make(fn)`,  if `fn` passes more than two
+  arguments to its callback, then these arguments will be transformed into an
+  array and passed to the Promise.  Previous versions would only ever return
+  the first value passed to the callback.

--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ provided, this new function will behave exactly like the original function.  If 
 is not provided, then the new function will return a Promise.
 
 Since Promises only allow a single value to be returned, if `fn` passes more than two arguments to `callback(...)`,
-then (as of v3.0.0) these arguments will be transformed into an array and passed to the Promise (although they will
-be left alone if the resulting function is called with a callback).  For example:
+then (as of v3.0.0) any arguments after the error will be transformed into an array and returned via the Promise as a
+single combined argument.  This does not affect the case where the transformed function is called with a callback.
+For example:
 
     var myFunc = pb.make(function(callback) {
         // We're returning multiple values via callback

--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ returns a new function which accepts an optional callback as its last parameter.
 provided, this new function will behave exactly like the original function.  If the callback
 is not provided, then the new function will return a Promise.
 
+Since Promises only allow a single value to be returned, if `fn` passes more than two arguments to `callback(...)`,
+then (as of v3.0.0) these arguments will be transformed into an array and passed to the Promise (although they will
+be left alone if the resulting function is called with a callback).  For example:
+
+    var myFunc = pb.make(function(callback) {
+        // We're returning multiple values via callback
+        callback(null, "a", "b");
+    })
+
+    // Callback style
+    myFunc(function(err, a, b) {...});
+
+    // Promise style
+    myFunc()
+    .then(function(results) {
+        // Promises only let us return a single value, so we return an array.
+        var a = results[0];
+        var b = results[1];
+        ...
+    })
+    .catch(function(err) {...});
+
 Note that `pb.make()` uses `fn.length` to determine how many arguments the function expects normally,
 so `pb.make()` will not work with functions that do not explicitly define their arguments in
 their function declaration.

--- a/index.js
+++ b/index.js
@@ -73,7 +73,12 @@
                 '                if(err) {\n' +
                 '                    reject(err);\n' +
                 '                } else {\n' +
-                '                    resolve(result);\n' +
+                                     // If multiple arguments were passed to the callback, then turn them into an array.
+                '                    if(arguments.length > 2) {' +
+                '                        resolve([].slice.call(arguments, 1));' +
+                '                    } else {' +
+                '                        resolve(result);\n' +
+                '                    }' +
                 '                }\n' +
                 '            });\n' +
                 '        });\n' +

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -109,6 +109,19 @@ describe 'making promises (make)', ->
         finally
             global.Promise = p
 
+    it 'should return multiple arguments passed to the callback as an array', ->
+        fn = promiseBreaker.make (done) -> done null, "a", "b"
+        expect(fn()).to.eventually.eql ["a", "b"]
+
+        fn = promiseBreaker.make (done) -> done null, "a", null
+        expect(fn()).to.eventually.eql ["a", null]
+
+        fn = promiseBreaker.make (done) -> done null, "a", undefined
+        expect(fn()).to.eventually.eql ["a", undefined]
+
+        fn = promiseBreaker.make (done) -> done null, "a"
+        expect(fn()).to.eventually.eql "a"
+
 describe "making callbacks (break)", ->
     fns = {
         add: (x) ->


### PR DESCRIPTION
For issue #3.
