### PR TITLE
Correctly handle exception from 'done'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,11 +109,11 @@
             var fn = new Function(['promiseFn'],
                 'return function(' + toList(args, 'done') + ') {\n' +
                 '    if(done) {\n' +
-                '        promiseFn.call(' + toList(params) + ').then(\n' +
                 // Call `done()` inside `setTimeout()`, so that if `done` throws an error, it will
                 // be turned into an uncaught exception, instead of being swallowed by the Promise.
+                '        promiseFn.call(' + toList(params) + ').then(\n' +
                 '            function(result) {setTimeout(function() {done(null, result);}, 0);},\n' +
-                '            function(err) {done(err);}\n' +
+                '            function(err) {setTimeout(function() {done(err);}, 0);}\n' +
                 '        );\n' +
                 '        return null;\n' +
                 '    } else {\n' +
@@ -158,13 +158,11 @@
             }
 
             if(done) {
+                // Call `done()` inside `setTimeout()`, so that if `done` throws an error, it will
+                // be turned into an uncaught exception, instead of being swallowed by the Promise.
                 answer.then(
-                    function(result) {
-                        // Call `done()` inside `setTimeout()`, so that if `done` throws an error, it will
-                        // be turned into an uncaught exception, instead of being swallowed by the Promise.
-                        setTimeout(function() {done(null, result);}, 0);
-                    },
-                    done
+                    function(result) {setTimeout(function() {done(null, result);}, 0);},
+                    function(err) {setTimeout(function() {done(err);}, 0);}
                 );
                 answer = null;
             }

--- a/index.js
+++ b/index.js
@@ -110,7 +110,9 @@
                 'return function(' + toList(args, 'done') + ') {\n' +
                 '    if(done) {\n' +
                 '        promiseFn.call(' + toList(params) + ').then(\n' +
-                '            function(result) {done(null, result);},\n' +
+                // Call `done()` inside `setTimeout()`, so that if `done` throws an error, it will
+                // be turned into an uncaught exception, instead of being swallowed by the Promise.
+                '            function(result) {setTimeout(function() {done(null, result);}, 0);},\n' +
                 '            function(err) {done(err);}\n' +
                 '        );\n' +
                 '        return null;\n' +
@@ -156,7 +158,14 @@
             }
 
             if(done) {
-                answer.then(function(result) {done(null, result);}, done);
+                answer.then(
+                    function(result) {
+                        // Call `done()` inside `setTimeout()`, so that if `done` throws an error, it will
+                        // be turned into an uncaught exception, instead of being swallowed by the Promise.
+                        setTimeout(function() {done(null, result);}, 0);
+                    },
+                    done
+                );
                 answer = null;
             }
 

--- a/test/addCallbackTest.js
+++ b/test/addCallbackTest.js
@@ -76,4 +76,18 @@ describe('addCallback', () => {
         );
 
     });
+
+    it('should deal correctly with exception from `done` (error case)', () => {
+        const fn = (done=null) => pb.addCallback(done, Promise.reject(new Error('boom1')));
+        const done = () => {throw new Error('boom')};
+
+        // We're calling into `fn`, but `done` is throwing an exception after `fn` is complete.  In
+        // an all-callback based world, this would cause an uncaught exception.  There's no better way to
+        // handle this, so make sure we get an uncaught exception here.
+        return expectUncaughtException(
+            () => fn(done)
+        );
+
+    });
+
 });

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,7 @@ const chai = require('chai');
 chai.use(require('chai-as-promised'));
 const {expect} = chai;
 
+const {expectUncaughtException} = require('./testUtils');
 const promiseBreaker = require('../index');
 
 const makeTestCases = function(testFn, fns) {
@@ -252,5 +253,17 @@ describe("Use custom promise", () => {
         .then(result => {
             expect(result).to.equal(3);
         });
+    });
+
+    it('should deal correctly with exception from `done`', () => {
+        const fn = promiseBreaker.break(() => Promise.resolve('hello'));
+        const done = () => {throw new Error('boom')};
+
+        // We're calling into `fn`, but `done` is throwing an exception after `fn` is complete.  In
+        // an all-callback based world, this would cause an uncaught exception.  There's no better way to
+        // handle this, so make sure we get an uncaught exception here.
+        return expectUncaughtException(
+            () => fn(done)
+        );
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -266,4 +266,16 @@ describe("Use custom promise", () => {
             () => fn(done)
         );
     });
+
+    it('should deal correctly with exception from `done` (error case)', () => {
+        const fn = promiseBreaker.break(() => Promise.reject(new Error('boom1')));
+        const done = () => {throw new Error('boom')};
+
+        // We're calling into `fn`, but `done` is throwing an exception after `fn` is complete.  In
+        // an all-callback based world, this would cause an uncaught exception.  There's no better way to
+        // handle this, so make sure we get an uncaught exception here.
+        return expectUncaughtException(
+            () => fn(done)
+        );
+    });
 });

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -1,0 +1,13 @@
+exports.expectUncaughtException = function(fn) {
+    // Remove mocha's uncaughtException handler.
+    const originalListeners = process.listeners('uncaughtException');
+    originalListeners.forEach(listener => process.removeListener('uncaughtException', listener));
+
+    return new Promise(resolve => {
+        process.once('uncaughtException', resolve);
+        fn();
+    })
+    .then(() => {
+        originalListeners.forEach(listener => process.on('uncaughtException', listener))
+    });
+}


### PR DESCRIPTION
@dule Maybe this PR will make our discussion from that loop issue clearer.  :)

So [here](https://github.com/jwalton/node-promise-breaker/blob/b1528258151f5608ffca9bef20b400a6a790166d/index.js#L165), if we didn't have the `setTimeout()`, then it would basically be: `.then(() => done(), done)`, right?  (Like the old code was.)

The problem here is if `done()` throws an exception, then where does the exception go?  We don't have a `.catch(...)` after the `.then()`, and we don't return a Promise here (since we're in the callback case), so there's no way anyone else can add a `catch()`.  So there's no where for the exception to go.  What will happen in a default node environment is this will turn into a "Potentially Unhandled Rejection" warning.

If this was all pure-callback based code, though, and we did the following:

```js
fn = myFunction(done) {done(null, "hello");}
fn(() => {throw new Error('boom');});
```

We'd obviously trigger the uncaught error handler.  We want that same behavior here, and the way we do that is to wrap the call to `done()` in a `setTimeout(..., 0)`, so we 'escape' the Promise chain.

